### PR TITLE
Fix #3.

### DIFF
--- a/dist/eukleides.js
+++ b/dist/eukleides.js
@@ -2677,6 +2677,8 @@ var SVGDrawer = /*#__PURE__*/function (_Drawer) {
           e = e.touches ? e.touches[0] : e;
           var m = element.getScreenCTM().inverse();
 
+          if (m.d > 0) m = m.flipY();
+
           var p = _this9.svg.createSVGPoint();
 
           p.x = e.clientX;

--- a/eukleides.js
+++ b/eukleides.js
@@ -1880,7 +1880,8 @@ class SVGDrawer extends Drawer {
             var onmove = (e) => {
                 e.preventDefault();
                 e = e.touches ? e.touches[0] : e;
-                const m = element.getScreenCTM().inverse();
+                let m = element.getScreenCTM().inverse();
+                if (m.d > 0) m = m.flipY();
                 const p = this.svg.createSVGPoint();
                 p.x = e.clientX;
                 p.y = e.clientY;


### PR DESCRIPTION
We use css to flip the y axis to match cartesian coordinates.

Some browsers include this into the transform matrix, but we need to add it for others.